### PR TITLE
Add workaround for ground targeting

### DIFF
--- a/Orbwalker/Config.cs
+++ b/Orbwalker/Config.cs
@@ -37,6 +37,7 @@ namespace Orbwalker
         public bool IsSlideAuto = true;
         public float Threshold = 0.5f;
         public int CastHold = 100;
+        public float GroundedHold = 1f;
 
         public bool PreventPassage = false;
         public bool PreventTCJ = false;

--- a/Orbwalker/Memory.cs
+++ b/Orbwalker/Memory.cs
@@ -62,11 +62,14 @@ namespace Orbwalker
 
         private bool UseActionDetour(ActionManager* am, ActionType type, uint acId, long target, uint a5, uint a6, uint a7, void* a8)
         {
-            if (C.Enabled && C.Buffer && !P.ShouldUnlock)
+            if (C.Enabled && C.Buffer && !P.ShouldUnlock && Util.CanUsePlugin())
             {
                 try
                 {
                     InternalLog.Verbose($"{type}, {acId}, {target}");
+                    if (Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().TryGetFirst(x => x.RowId == acId, out var sheetAct) && sheetAct.TargetArea && sheetAct.Cast100ms > 0)
+                        P.BlockMovementUntil = Environment.TickCount64 + (long)(P.Config.GroundedHold * 1000);
+
                     if (P.DelayedAction == null && ((type == ActionType.Spell && Util.IsActionCastable(acId)) || type == ActionType.Mount) && Util.GCD == 0 && AgentMap.Instance()->IsPlayerMoving != 0 && !am->ActionQueued && !Util.CheckTpRetMnt(acId, type))
                     {
                         P.DelayedAction = new(acId, type, 0, target, a5, a6, a7, a8);

--- a/Orbwalker/UI.cs
+++ b/Orbwalker/UI.cs
@@ -151,6 +151,24 @@ namespace Orbwalker
                     ImGui.EndCombo();
                 }
             }
+
+            ImGui.PushItemWidth(300);
+            ImGuiEx.TextV($"Ground Targeting Hold (seconds):");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(100f);
+
+            if (ImGui.InputFloat("###GroundedHoldConfig", ref P.Config.GroundedHold,0,0,"%.2g"))
+            {
+                if (P.Config.GroundedHold <= 0)
+                    P.Config.GroundedHold = 0;
+
+                if (P.Config.GroundedHold % 0.01f != 0)
+                    P.Config.GroundedHold = (float)Math.Round(P.Config.GroundedHold, 2, MidpointRounding.ToNegativeInfinity);
+            }
+
+            ImGuiComponents.HelpMarker($"Spells which have cast times that are also targeted on the ground (mainly found in BLU) register casting as the target appears, and will cancel cast times if moving as it's confirmed. " +
+                $"This option forces your character to stop as the target appears for however long as to not cancel the cast pre-emptively.");
+
             ImGuiGroup.EndGroupBox();
 
             ImGuiEx.Text($"Jobs");
@@ -186,7 +204,7 @@ namespace Orbwalker
                 }
             }
             ImGui.Separator();
-            ImGui.Columns(8, "###JobGrid", false);
+            ImGui.Columns(5, "###JobGrid", false);
             foreach (var job in Enum.GetValues<Job>())
             {
                 if (job == Job.ADV) continue;

--- a/Orbwalker/Util.cs
+++ b/Orbwalker/Util.cs
@@ -63,8 +63,7 @@ namespace Orbwalker
         {
             if (!Player.Available) return false;
             if (Svc.ClientState.IsPvP && !C.PVP) return false;
-            if (C.BlockMount || C.BlockReturn || C.BlockTP) return true;
-
+            
             Job currentJob = (Job)Player.Object.ClassJob.Id;
 
             if (!P.Config.EnabledJobs.ContainsKey(currentJob)) return false;


### PR DESCRIPTION
Ground targeting is annoying. Similar to mounts, cancels if moving before it, but in this case the action is considered used when the targeting reticule appears, not when the spell is casted. This adds a user config to customize how long to be held in place if using a ground targeted spell with a cast time. 