### PR TITLE
Patched Spells to Actions, implemented less brute forced movement prevention

### DIFF
--- a/Orbwalker/Memory.cs
+++ b/Orbwalker/Memory.cs
@@ -85,7 +85,7 @@ namespace Orbwalker
             if (*hold == (MButtonHoldState.Left | MButtonHoldState.Right)) {
                 *hold = 0;
             }
-            // GagSpeak.Log.Debug($"{((IntPtr)hold).ToString("X")}");
+            //PluginLog.Debug($"{((IntPtr)hold).ToString("X")}");
             // update the original
             byte ret = MouseMovePreventerHook.Original(thisx);
             // restore the original

--- a/Orbwalker/Memory.cs
+++ b/Orbwalker/Memory.cs
@@ -4,13 +4,9 @@ using Dalamud.Utility.Signatures;
 using ECommons.Hooks;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using Lumina.Excel.GeneratedSheets;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using MButtonHoldState = FFXIVClientStructs.FFXIV.Client.Game.Control.InputManager.MouseButtonHoldState;
+using FFXIVClientStructs.FFXIV.Client.Game.Control;
 
 namespace Orbwalker
 {
@@ -22,7 +18,7 @@ namespace Orbwalker
         {
             UseActionHook = Svc.Hook.HookFromAddress<UseActionDelegate>((nint)ActionManager.Addresses.UseAction.Value, UseActionDetour);
             SignatureHelper.Initialise(this);
-            PluginLog.Debug($"forceDisableMovementPtr = {forceDisableMovementPtr:X16}");
+            //PluginLog.Debug($"forceDisableMovementPtr = {forceDisableMovementPtr:X16}");
             SendAction.Init((long targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9) =>
             {
                 if (Util.GetMovePreventionActions().Contains(actionId))
@@ -55,7 +51,8 @@ namespace Orbwalker
                 try
                 {
                     InternalLog.Verbose($"{type}, {acId}, {target}");
-                    if (P.DelayedAction == null && ((type == ActionType.Spell && Util.IsActionCastable(acId)) || type == ActionType.Mount) && Util.GCD == 0 && AgentMap.Instance()->IsPlayerMoving != 0 && !am->ActionQueued && !Util.CheckTpRetMnt(acId, type))
+                    // was ActionType.Spell before, changed because outdated
+                    if (P.DelayedAction == null && ((type == ActionType.Action && Util.IsActionCastable(acId)) || type == ActionType.Mount) && Util.GCD == 0 && AgentMap.Instance()->IsPlayerMoving != 0 && !am->ActionQueued && !Util.CheckTpRetMnt(acId, type))
                     {
                         P.DelayedAction = new(acId, type, 0, target, a5, a6, a7, a8);
                         return false;
@@ -70,9 +67,35 @@ namespace Orbwalker
             return ret;
         }
 
-        [Signature("F3 0F 10 05 ?? ?? ?? ?? 0F 2E C6 0F 8A", ScanType = ScanType.StaticAddress, Fallibility = Fallibility.Infallible)]
-        private nint forceDisableMovementPtr;
-        internal ref int ForceDisableMovement => ref *(int*)(forceDisableMovementPtr + 4);
+        // [Signature("F3 0F 10 05 ?? ?? ?? ?? 0F 2E C6 0F 8A", ScanType = ScanType.StaticAddress, Fallibility = Fallibility.Infallible)]
+        // private nint forceDisableMovementPtr;
+        // internal ref int ForceDisableMovement => ref *(int*)(forceDisableMovementPtr + 4);
+
+        // better for preventing mouse movements in both camera modes
+        public unsafe delegate byte MoveOnMousePreventorDelegate(MoveControllerSubMemberForMine* thisx);
+        [Signature("40 55 53 48 8d 6c 24 c8 48 81 ec 38 01 00 00", DetourName = nameof(MovementUpdate), Fallibility = Fallibility.Auto)]
+        private static Hook<MoveOnMousePreventorDelegate>? MouseMovePreventerHook { get; set; } = null!;
+        [return: MarshalAs(UnmanagedType.U1)]
+        public unsafe byte MovementUpdate(MoveControllerSubMemberForMine* thisx) { // was static before.
+            // get the current mouse button hole state, note that because we are doing this during the move update,
+            // we are getting and updating the mouse state PRIOR to the game doing so, allowing us to change it
+            MButtonHoldState* hold = InputManager.GetMouseButtonHoldState();
+            MButtonHoldState original = *hold;
+            // modify the hold state
+            if (*hold == (MButtonHoldState.Left | MButtonHoldState.Right)) {
+                *hold = 0;
+            }
+            // GagSpeak.Log.Debug($"{((IntPtr)hold).ToString("X")}");
+            // update the original
+            byte ret = MouseMovePreventerHook.Original(thisx);
+            // restore the original
+            *hold = original;
+            // return 
+            return ret;
+        }
+
+
+
 
         delegate byte InputData_IsInputIDKeyPressedDelegate(nint a1, int key);
         [Signature("E8 ?? ?? ?? ?? 84 C0 48 63 03", DetourName =nameof(InputData_IsInputIDKeyPressedDetour), Fallibility = Fallibility.Infallible)]
@@ -119,7 +142,7 @@ namespace Orbwalker
 
         internal void EnableHooks()
         {
-            
+            MouseMovePreventerHook.Enable();            
             InputData_IsInputIDKeyPressedHook.Enable();
             InputData_IsInputIDKeyClickedHook.Enable();
             InputData_IsInputIDKeyHeldHook.Enable();
@@ -128,6 +151,7 @@ namespace Orbwalker
 
         internal void DisableHooks()
         {
+            MouseMovePreventerHook.Disable();
             InputData_IsInputIDKeyPressedHook.Disable();
             InputData_IsInputIDKeyClickedHook.Disable();
             InputData_IsInputIDKeyHeldHook.Disable();
@@ -137,6 +161,7 @@ namespace Orbwalker
         public void Dispose()
         {
             DisableHooks();
+            MouseMovePreventerHook.Dispose();
             InputData_IsInputIDKeyPressedHook.Dispose();
             InputData_IsInputIDKeyClickedHook.Dispose();
             InputData_IsInputIDKeyHeldHook.Dispose();
@@ -144,5 +169,51 @@ namespace Orbwalker
             UseActionHook.Disable();
             UseActionHook.Dispose();
         }
+    }
+
+
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe struct UnkGameObjectStruct {
+        [FieldOffset(0xD0)] public int Unk_0xD0;
+        [FieldOffset(0x101)] public byte Unk_0x101;
+        [FieldOffset(0x1C0)] public Vector3 DesiredPosition;
+        [FieldOffset(0x1D0)] public float NewRotation;
+        [FieldOffset(0x1FC)] public byte Unk_0x1FC;
+        [FieldOffset(0x1FF)] public byte Unk_0x1FF;
+        [FieldOffset(0x200)] public byte Unk_0x200;
+        [FieldOffset(0x2C6)] public byte Unk_0x2C6;
+        [FieldOffset(0x3D0)] public GameObject* Actor; // points to local player
+        [FieldOffset(0x3E0)] public byte Unk_0x3E0;
+        [FieldOffset(0x3EC)] public float Unk_0x3EC;
+        [FieldOffset(0x3F0)] public float Unk_0x3F0;
+        [FieldOffset(0x418)] public byte Unk_0x418;
+        [FieldOffset(0x419)] public byte Unk_0x419;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe struct MoveControllerSubMemberForMine {
+        [FieldOffset(0x10)] public Vector3 Direction;
+        [FieldOffset(0x20)] public UnkGameObjectStruct* ActorStruct;
+        [FieldOffset(0x28)] public uint Unk_0x28;
+        [FieldOffset(0x3C)] public byte Moved;
+        [FieldOffset(0x3D)] public byte Rotated;
+        [FieldOffset(0x3E)] public byte MovementLock;
+        [FieldOffset(0x3F)] public byte Unk_0x3F;
+        [FieldOffset(0x40)] public byte Unk_0x40;
+        [FieldOffset(0x80)] public Vector3 ZoningPosition;
+        [FieldOffset(0xF4)] public byte Unk_0xF4;
+        [FieldOffset(0x80)] public Vector3 Unk_0x80;
+        [FieldOffset(0x90)] public float MoveDir;
+        [FieldOffset(0x94)] public byte Unk_0x94;
+        [FieldOffset(0xA0)] public Vector3 MoveForward;
+        [FieldOffset(0xB0)] public float Unk_0xB0;
+        [FieldOffset(0x104)] public byte Unk_0x104;
+        [FieldOffset(0x110)] public Int32 WishdirChanged;
+        [FieldOffset(0x114)] public float Wishdir_Horizontal;
+        [FieldOffset(0x118)] public float Wishdir_Vertical;
+        [FieldOffset(0x120)] public byte Unk_0x120;
+        [FieldOffset(0x121)] public byte Rotated1;
+        [FieldOffset(0x122)] public byte Unk_0x122;
+        [FieldOffset(0x123)] public byte Unk_0x123;
     }
 }

--- a/Orbwalker/MoveManager.cs
+++ b/Orbwalker/MoveManager.cs
@@ -15,12 +15,12 @@ namespace Orbwalker
         {
             if (MovingDisabled)
             {
-                PluginLog.Debug($"Enabling moving, cnt {P.Memory.ForceDisableMovement}");
+                PluginLog.Debug($"Enabling moving"); // , cnt {P.Memory.ForceDisableMovement}");
                 P.Memory.DisableHooks();
-                if (P.Memory.ForceDisableMovement > 0)
-                {
-                    P.Memory.ForceDisableMovement--;
-                }
+                // if (P.Memory.ForceDisableMovement > 0)
+                // {
+                //     P.Memory.ForceDisableMovement--;
+                // }
                 MovingDisabled = false;
             }
         }
@@ -29,9 +29,9 @@ namespace Orbwalker
         {
             if (!MovingDisabled)
             {
-                PluginLog.Debug($"Disabling moving, cnt {P.Memory.ForceDisableMovement}");
+                PluginLog.Debug($"Disabling moving"); // , cnt {P.Memory.ForceDisableMovement}");
                 P.Memory.EnableHooks();
-                P.Memory.ForceDisableMovement++;
+                // P.Memory.ForceDisableMovement++;
                 MovingDisabled = true;
             }
         }

--- a/Orbwalker/UI.cs
+++ b/Orbwalker/UI.cs
@@ -303,11 +303,12 @@ namespace Orbwalker
 
         static void Debug()
         {
-            ImGui.InputInt($"forceDisableMovementPtr", ref P.Memory.ForceDisableMovement);
+            //ImGui.InputInt($"forceDisableMovementPtr", ref P.Memory.ForceDisableMovement);
             if (Svc.Targets.Target != null)
             {
                 var addInfo = stackalloc uint[1];
-                ImGuiEx.Text($"{ActionManager.Instance()->GetActionStatus(ActionType.Spell, 16541, Svc.Targets.Target.Struct()->GetObjectID(), outOptExtraInfo: addInfo)} / {*addInfo}");
+                // was spell before, fixed
+                ImGuiEx.Text($"{ActionManager.Instance()->GetActionStatus(ActionType.Action, 16541, Svc.Targets.Target.Struct()->GetObjectID(), outOptExtraInfo: addInfo)} / {*addInfo}");
             }
             ImGuiEx.Text($"GCD: {Util.GCD}\nRCorGRD:{Util.GetRCorGDC()}");
         }

--- a/Orbwalker/Util.cs
+++ b/Orbwalker/Util.cs
@@ -96,7 +96,7 @@ namespace Orbwalker
             }
 
             var actionManager = ActionManager.Instance();
-            var adjustedCastTime = ActionManager.GetAdjustedCastTime(ActionType.Spell, id);
+            var adjustedCastTime = ActionManager.GetAdjustedCastTime(ActionType.Action, id);
 
             return adjustedCastTime > 0;
         }


### PR DESCRIPTION
Does not block all movement, but rather solves the single use case it was intended to prevent.

The new hook simply registers movement prior to the updates occurring, and resets mouse state if at any point during the movement update both are held down.

It will then return the movement with the mouse state of zero by updating mouse state before returning original, then returning mouse state after the original is returned so it can be properly used by other calls that need it outside of movement.