### PR TITLE
DT Fix for advanced MouseAutoMovePreventor

### DIFF
--- a/Orbwalker/Memory.cs
+++ b/Orbwalker/Memory.cs
@@ -139,6 +139,7 @@ namespace Orbwalker
             InputData_IsInputIDKeyHeldHook.Enable();
             InputData_IsInputIDKeyReleasedHook.Enable();
         }
+
         internal void EnableMouseAutoMoveHook()
         {
             MouseAutoMoveHook.Enable();
@@ -153,10 +154,15 @@ namespace Orbwalker
             InputData_IsInputIDKeyReleasedHook.Disable();
         }
 
+        internal void DisableMouseAutoMoveHook()
+        {
+            MouseAutoMoveHook.Disable();
+        }
+
         public void Dispose()
         {
             DisableHooks();
-            MouseAutoMoveHook.Dispose();
+            DisableMouseAutoMoveHook();
             InputData_IsInputIDKeyPressedHook.Dispose();
             InputData_IsInputIDKeyClickedHook.Dispose();
             InputData_IsInputIDKeyHeldHook.Dispose();

--- a/Orbwalker/Memory.cs
+++ b/Orbwalker/Memory.cs
@@ -76,29 +76,17 @@ namespace Orbwalker
         internal ref int ForceDisableMovement => ref *(int*)(forceDisableMovementPtr + 4);
 
         // better for preventing mouse movements in both camera modes
-        public unsafe delegate byte MoveOnMousePreventorDelegate(MoveControllerSubMemberForMine* thisx);
-        [Signature("40 55 53 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 83 79", DetourName = nameof(MovementUpdate), Fallibility = Fallibility.Auto)]
-        private static Hook<MoveOnMousePreventorDelegate>? MouseMovePreventerHook { get; set; } = null!;
+        public unsafe delegate void MoveOnMousePreventerDelegate(MoveControllerSubMemberForMine* thisx, float wishdir_h, float wishdir_v, char arg4, byte align_with_camera, Vector3* direction);
+        [Signature("48 8b C4 48 89 70 ?? 48 89 78 ?? 55 41 56 41 57", DetourName = nameof(MovementUpdate), Fallibility = Fallibility.Auto)]
+        public static Hook<MoveOnMousePreventerDelegate>? MouseAutoMoveHook { get; set; } = null!;
         [return: MarshalAs(UnmanagedType.U1)]
-        public unsafe byte MovementUpdate(MoveControllerSubMemberForMine* thisx) { // was static before.
-            // get the current mouse button hole state, note that because we are doing this during the move update,
-            // we are getting and updating the mouse state PRIOR to the game doing so, allowing us to change it
-            MButtonHoldState* hold = InputManager.GetMouseButtonHoldState();
-            MButtonHoldState original = *hold;
-            // modify the hold state
-            if (*hold == (MButtonHoldState.Left | MButtonHoldState.Right)) {
-                *hold = 0;
-            }
-            //PluginLog.Debug($"{((IntPtr)hold).ToString("X")}");
-            // update the original
-            byte ret = MouseMovePreventerHook.Original(thisx);
-            // restore the original
-            *hold = original;
-            // return 
-            return ret;
+        public static unsafe void MovementUpdate(MoveControllerSubMemberForMine* thisx, float wishdir_h, float wishdir_v, char arg4, byte align_with_camera, Vector3* direction)
+        {
+            if (thisx->Unk_0x3F != 0)
+                return;
+
+            MouseAutoMoveHook.Original(thisx, wishdir_h, wishdir_v, arg4, align_with_camera, direction);
         }
-
-
 
 
         delegate byte InputData_IsInputIDKeyPressedDelegate(nint a1, int key);
@@ -146,16 +134,19 @@ namespace Orbwalker
 
         internal void EnableHooks()
         {
-            MouseMovePreventerHook.Enable();            
             InputData_IsInputIDKeyPressedHook.Enable();
             InputData_IsInputIDKeyClickedHook.Enable();
             InputData_IsInputIDKeyHeldHook.Enable();
             InputData_IsInputIDKeyReleasedHook.Enable();
         }
+        internal void EnableMouseAutoMoveHook()
+        {
+            MouseAutoMoveHook.Enable();
+        }
 
         internal void DisableHooks()
         {
-            MouseMovePreventerHook.Disable();
+            MouseAutoMoveHook.Disable();
             InputData_IsInputIDKeyPressedHook.Disable();
             InputData_IsInputIDKeyClickedHook.Disable();
             InputData_IsInputIDKeyHeldHook.Disable();
@@ -165,7 +156,7 @@ namespace Orbwalker
         public void Dispose()
         {
             DisableHooks();
-            MouseMovePreventerHook.Dispose();
+            MouseAutoMoveHook.Dispose();
             InputData_IsInputIDKeyPressedHook.Dispose();
             InputData_IsInputIDKeyClickedHook.Dispose();
             InputData_IsInputIDKeyHeldHook.Dispose();
@@ -177,7 +168,8 @@ namespace Orbwalker
 
 
     [StructLayout(LayoutKind.Explicit)]
-    public unsafe struct UnkGameObjectStruct {
+    public unsafe struct UnkGameObjectStruct
+    {
         [FieldOffset(0xD0)] public int Unk_0xD0;
         [FieldOffset(0x101)] public byte Unk_0x101;
         [FieldOffset(0x1C0)] public Vector3 DesiredPosition;
@@ -186,7 +178,7 @@ namespace Orbwalker
         [FieldOffset(0x1FF)] public byte Unk_0x1FF;
         [FieldOffset(0x200)] public byte Unk_0x200;
         [FieldOffset(0x2C6)] public byte Unk_0x2C6;
-        [FieldOffset(0x3D0)] public GameObject* Actor; // points to local player
+        [FieldOffset(0x3D0)] public GameObject* Actor; // Points to local player
         [FieldOffset(0x3E0)] public byte Unk_0x3E0;
         [FieldOffset(0x3EC)] public float Unk_0x3EC;
         [FieldOffset(0x3F0)] public float Unk_0x3F0;
@@ -195,22 +187,30 @@ namespace Orbwalker
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    public unsafe struct MoveControllerSubMemberForMine {
+    public unsafe struct MoveControllerSubMemberForMine
+    {
         [FieldOffset(0x10)] public Vector3 Direction;
         [FieldOffset(0x20)] public UnkGameObjectStruct* ActorStruct;
-        [FieldOffset(0x28)] public uint Unk_0x28;
-        [FieldOffset(0x3C)] public byte Moved;
-        [FieldOffset(0x3D)] public byte Rotated;
+        [FieldOffset(0x28)] public float Unk_0x28;
+        [FieldOffset(0x38)] public float Unk_0x38;
+        [FieldOffset(0x3C)] public byte Moved; // 1 when the character has moved
+        [FieldOffset(0x3D)] public byte Rotated; // 1 when the character has rotated
         [FieldOffset(0x3E)] public byte MovementLock;
-        [FieldOffset(0x3F)] public byte Unk_0x3F;
+        [FieldOffset(0x3F)] public byte Unk_0x3F; // non-zero when moving with LMB+RMB
         [FieldOffset(0x40)] public byte Unk_0x40;
+        [FieldOffset(0x44)] public float MoveSpeed;
+        [FieldOffset(0x50)] public float* MoveSpeedMaximums;
         [FieldOffset(0x80)] public Vector3 ZoningPosition;
-        [FieldOffset(0xF4)] public byte Unk_0xF4;
-        [FieldOffset(0x80)] public Vector3 Unk_0x80;
         [FieldOffset(0x90)] public float MoveDir;
         [FieldOffset(0x94)] public byte Unk_0x94;
-        [FieldOffset(0xA0)] public Vector3 MoveForward;
+        [FieldOffset(0xA0)] public Vector3 MoveForward; // direction output by MovementUpdate
         [FieldOffset(0xB0)] public float Unk_0xB0;
+        [FieldOffset(0xB4)] public byte Unk_0xB4;
+        [FieldOffset(0xF2)] public byte Unk_0xF2;
+        [FieldOffset(0xF3)] public byte Unk_0xF3;
+        [FieldOffset(0xF4)] public byte Unk_0xF4;
+        [FieldOffset(0xF5)] public byte Unk_0xF5;
+        [FieldOffset(0xF6)] public byte Unk_0xF6;
         [FieldOffset(0x104)] public byte Unk_0x104;
         [FieldOffset(0x110)] public Int32 WishdirChanged;
         [FieldOffset(0x114)] public float Wishdir_Horizontal;
@@ -219,5 +219,7 @@ namespace Orbwalker
         [FieldOffset(0x121)] public byte Rotated1;
         [FieldOffset(0x122)] public byte Unk_0x122;
         [FieldOffset(0x123)] public byte Unk_0x123;
+        [FieldOffset(0x125)] public byte Unk_0x125;
+        [FieldOffset(0x12A)] public byte Unk_0x12A;
     }
 }

--- a/Orbwalker/MoveManager.cs
+++ b/Orbwalker/MoveManager.cs
@@ -4,6 +4,7 @@
     {
         internal static readonly int[] BlockedKeys = new int[] { 321, 322, 323, 324, 325, 326 };
         internal static bool MovingDisabled { get; private set; } = false;
+        internal static bool MouseMovingDisabled { get; private set; } = false;
 
         internal unsafe static void EnableMoving()
         {
@@ -21,6 +22,17 @@
                     }
                 }
                 MovingDisabled = false;
+            }
+        }
+
+        internal unsafe static void EnableMouseMoving()
+        {
+            if (MouseMovingDisabled)
+            {
+                PluginLog.Debug($"Enabling Mouse Moving");
+                // Handle WASD Movement (and LMB+RMB Movement, if enabled)
+                P.Memory.DisableMouseAutoMoveHook();
+                MouseMovingDisabled = false;
             }
         }
 
@@ -44,6 +56,17 @@
                     P.Memory.ForceDisableMovement++;
                 }
                 MovingDisabled = true;
+            }
+        }
+
+        internal static void DisableMouseMoving()
+        {
+            if (!MouseMovingDisabled)
+            {
+                PluginLog.Debug($"Disabling Mouse moving");
+                // Handle LMB+RMB movement
+                P.Memory.EnableMouseAutoMoveHook();
+                MouseMovingDisabled = true;
             }
         }
     }

--- a/Orbwalker/MoveManager.cs
+++ b/Orbwalker/MoveManager.cs
@@ -10,8 +10,10 @@
             if (MovingDisabled)
             {
                 PluginLog.Debug($"Enabling moving"); // , cnt {P.Memory.ForceDisableMovement}");
+                // Handle WASD Movement (and LMB+RMB Movement, if enabled)
                 P.Memory.DisableHooks();
-                if (!C.DisableMouseDisabling || C.ControllerMode)
+                // Handle Controller based Movement
+                if(C.ControllerMode)
                 {
                     if (P.Memory.ForceDisableMovement > 0)
                     {
@@ -27,8 +29,17 @@
             if (!MovingDisabled)
             {
                 PluginLog.Debug($"Disabling moving"); // , cnt {P.Memory.ForceDisableMovement}");
+                // Handle WASD Movement
                 P.Memory.EnableHooks();
-                if ((!C.DisableMouseDisabling && Util.IsMouseMoveOrdered()) || C.ControllerMode)
+
+                // Handle LMB+RMB movement
+                if (!C.DisableMouseDisabling)
+                {
+                    P.Memory.EnableMouseAutoMoveHook();
+                }
+
+                // Handle Controller based Movement
+                if(C.ControllerMode)
                 {
                     P.Memory.ForceDisableMovement++;
                 }

--- a/Orbwalker/Orbwalker.cs
+++ b/Orbwalker/Orbwalker.cs
@@ -163,7 +163,7 @@ namespace Orbwalker
 
         private void HandleMovementPrevention()
         {
-            if ((!C.DisableMouseDisabling && Util.IsMouseMoveOrdered()) || C.ControllerMode || IsStronglyLocked)
+            if (!C.DisableMouseDisabling || C.ControllerMode || IsStronglyLocked)
             {
                 MoveManager.DisableMoving();
             }

--- a/Orbwalker/Orbwalker.cs
+++ b/Orbwalker/Orbwalker.cs
@@ -87,6 +87,7 @@ namespace Orbwalker
             else
             {
                 MoveManager.EnableMoving();
+                MoveManager.EnableMouseMoving();
             }
         }
 
@@ -163,13 +164,22 @@ namespace Orbwalker
 
         private void HandleMovementPrevention()
         {
-            if (!C.DisableMouseDisabling || C.ControllerMode || IsStronglyLocked)
+            if (C.ControllerMode || IsStronglyLocked)
             {
                 MoveManager.DisableMoving();
             }
             else
             {
                 MoveManager.EnableMoving();
+            }
+
+            if (!C.DisableMouseDisabling)
+            {
+                MoveManager.DisableMouseMoving();
+            }
+            else
+            {
+                MoveManager.EnableMouseMoving();
             }
 
             CancelMoveKeys();
@@ -191,6 +201,7 @@ namespace Orbwalker
         private void EnableMoving()
         {
             MoveManager.EnableMoving();
+            MoveManager.EnableMouseMoving();
         }
 
         private void ResetCancelledMoveKeys()
@@ -213,6 +224,7 @@ namespace Orbwalker
         {
             Svc.Framework.Update -= Framework_Update;
             MoveManager.EnableMoving();
+            MoveManager.EnableMouseMoving();
             Memory.Dispose();
             ECommonsMain.Dispose();
         }

--- a/Orbwalker/Util.cs
+++ b/Orbwalker/Util.cs
@@ -100,10 +100,5 @@ namespace Orbwalker
 
             return adjustedCastTime > 0;
         }
-
-        internal static bool IsMouseMoveOrdered()
-        {
-            return IsKeyPressed((int)Keys.LButton) && IsKeyPressed((int)Keys.RButton);
-        }
     }
 }


### PR DESCRIPTION
Added DT Fix for advanced MouseAutoMovePreventor.

Replaced Util.MouseMoveRequested with this.

100% more SPEEEN

(still compatible with the 'Enable Mouse Button Release' Option)